### PR TITLE
Upgrade action to use node16

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -2,7 +2,7 @@ name: 'Extract version from tag'
 description: 'Create multiple variables from the extracted tag version'
 author: 'damienaicheh'
 runs:
-  using: 'node12'
+  using: 'node16'
   main: 'dist/index.js'
 branding:
   icon: 'tag'


### PR DESCRIPTION
Github will deprecate node 12 and all actions will run on node 16
https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/